### PR TITLE
Fix ai drone respawn bug

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -447,8 +447,9 @@ async def respawn_ai(ai_id: str, delay: float):
     await asyncio.sleep(delay)
     if ai_id in game_state.ai_drones:
         # AI의 소유자 찾기
-        owner_id = '_'.join(ai_id.split('_')[:2])  # "ai_player_XXX" → "player_XXX"
-        owner_id = owner_id.replace('ai_', '')
+        # ai_id 형식: "ai_{client_id}_{index}" → 원래 client_id 복원
+        owner_and_index = ai_id[3:]  # "ai_" 접두사 제거
+        owner_id = owner_and_index.rsplit('_', 1)[0]
         
         if owner_id in game_state.player_maps:
             ai_drone = game_state.ai_drones[ai_id]


### PR DESCRIPTION
Fix AI drone respawn issue by correcting owner ID extraction from AI ID.

The previous logic for extracting `owner_id` from `ai_id` (e.g., `ai_player_XXX_0`) was flawed, leading to an incorrect `owner_id` value. This caused the `game_state.player_maps` lookup to fail, preventing the `respawn_ai` function from executing the actual respawn process for the drone.

---
<a href="https://cursor.com/background-agent?bcId=bc-a1e34949-db25-4db3-9c28-f47b1fb3a18b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a1e34949-db25-4db3-9c28-f47b1fb3a18b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

