### PR TITLE
Fix player exp to next level error

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -396,7 +396,7 @@ async def game_loop():
                                 'coin_reward': 10,
                                 'exp_reward': 10,
                                 'current_exp': player.experience,
-                                'max_exp': player.exp_to_next_level
+                                'max_exp': player.get_experience_to_next_level()
                             })
                             
                             # 미사일 적중으로 레벨업 확인


### PR DESCRIPTION
Fix `AttributeError` by calling `player.get_experience_to_next_level()` instead of accessing a non-existent `exp_to_next_level` attribute.

---
<a href="https://cursor.com/background-agent?bcId=bc-98d47409-50a8-45b4-8b67-b05ea48608a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-98d47409-50a8-45b4-8b67-b05ea48608a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

